### PR TITLE
ci: add majorver GitHub actions on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
       contents: write # Needed to create release notes
     runs-on: ubuntu-latest
     steps:
+      - uses: nowactions/update-majorver@v1
+      
       - uses: ncipollo/release-action@v1
         with:
           generateReleaseNotes: true


### PR DESCRIPTION
## Why

Because I want to point the major version to the latest release too.